### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -445,7 +445,7 @@ function merger(deep, ...objects) {
       if (deep &&
           type.object(t[k]) &&
           !(t[k] instanceof Monkey) &&
-          !isPrototypePolluted(k)) {
+          !(k === '__proto__' || k === 'constructor' || k === 'prototype')) {
         o[k] = merger(true, o[k] || {}, t[k]);
       }
       else {
@@ -618,12 +618,3 @@ const uniqid = (function() {
 })();
 
 export {uniqid};
-
-/**
- * Blacklist certain keys to prevent Prototype Pollution
- * @param {any} key  - Object key to check
- * @return {boolean} - Key is blacklisted or not
- */
-function isPrototypePolluted(key) {
-  return ['__proto__', 'constructor', 'prototype'].includes(key);
-}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -444,7 +444,8 @@ function merger(deep, ...objects) {
     for (k in t) {
       if (deep &&
           type.object(t[k]) &&
-          !(t[k] instanceof Monkey)) {
+          !(t[k] instanceof Monkey) &&
+          !isPrototypePolluted(k)) {
         o[k] = merger(true, o[k] || {}, t[k]);
       }
       else {
@@ -617,3 +618,12 @@ const uniqid = (function() {
 })();
 
 export {uniqid};
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {any} key  - Object key to check
+ * @return {boolean} - Key is blacklisted or not
+ */
+function isPrototypePolluted(key) {
+  return /__proto__|constructor|prototype/.test(key);
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -625,5 +625,5 @@ export {uniqid};
  * @return {boolean} - Key is blacklisted or not
  */
 function isPrototypePolluted(key) {
-  return /__proto__|constructor|prototype/.test(key);
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }

--- a/test/suites/helpers.ts
+++ b/test/suites/helpers.ts
@@ -94,6 +94,14 @@ describe('Helpers', function() {
         {one: {two: [3, 4]}, three: 3}
       );
     });
+
+    it('merge should not pollute object prototype.', function() {
+      const data = JSON.parse('{"__proto__": {"polluted": true}}');
+
+      deepMerge({}, data);
+
+      assert.equal(Object.keys(Object.prototype).includes('polluted'), false);
+    });
   });
 
   /**


### PR DESCRIPTION
### :bar_chart: Metadata *

`baobab` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-baobab

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const Baobab = require('baobab');

console.log(`Before: ${{}.polluted}`)
tree = new Baobab()
tree.deepMerge(JSON.parse('{"__proto__": {"polluted": true}}'))
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i baobab # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105388471-b4708c00-5c3c-11eb-86d4-959cf2422322.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
